### PR TITLE
Made a decent check to ensure that the description is not whitespace only

### DIFF
--- a/src/commands/embed.ts
+++ b/src/commands/embed.ts
@@ -1,7 +1,7 @@
 import {
   ApplicationCommandOptionType,
   CommandInteraction,
-  EmbedBuilder
+  EmbedBuilder,
 } from "discord.js";
 import { Discord, Slash, SlashChoice, SlashOption } from "discordx";
 import { ErrorHandler } from "../utils/error_handler.js";
@@ -11,7 +11,7 @@ export class Command {
   @Slash({
     name: "embed",
     description: "Create an Embed",
-    dmPermission: true
+    dmPermission: true,
   })
   async command(
     @SlashOption({
@@ -66,16 +66,20 @@ export class Command {
     interaction: CommandInteraction
   ) {
     try {
-      if (title === undefined && description === undefined) {
+      if (
+        title === undefined &&
+        (description === undefined || description.match(/^\s*$/))
+      ) {
         title = "Someone forgot to add a title and a description";
         description = "May this user drown in laughter";
       }
-      const embed = new EmbedBuilder()
-        .setColor(colour || "#c4a7e7");
+      const embed = new EmbedBuilder().setColor(colour || "#c4a7e7");
       title ? embed.setTitle(title) : void 0;
-      description ? embed.setDescription(description.replaceAll("\\n", "\n")) : void 0;
+      description
+        ? embed.setDescription(description.replaceAll("\\n", "\n"))
+        : void 0;
       timestamp ? embed.setTimestamp() : void 0;
-      
+
       interaction.reply({ embeds: [embed] });
     } catch (e) {
       await ErrorHandler(e, interaction);


### PR DESCRIPTION
Discord trims trailing whitespace from embed descriptions; this causes issues when the description is only whitespace. We want it to be able to not have a title, so instead I just check if the description is whitespace only; effectively, it's a more thorough check to ensure that the description will be valid.